### PR TITLE
Drop mypy from the project

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -7,6 +7,8 @@ This document records all notable changes to `Skeleton-Pyspark <https://github.c
 0.2.1 (2021-May-07)
 ---------------------
 
+* Bugfix/Drop mypy whose good parts are mostly covered by flake8-annotations
+
 * Feature/Ability to package and send dependency to the cluster (Stage 2)
 https://www.notion.so/dataroots/Pyspark-metho-as-code-repo-d2ea171872604cc1bbf062cf4131373f
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "src"
-version = "0.2.0"
+version = "0.2.1"
 description = ""
 authors = ["Dataroots <info@dataroots.io>"]
 license = "MIT"
@@ -19,7 +19,6 @@ black = "^20.8b1"
 bandit = "^1.7.0"
 flake8-annotations = "^2.6.2"
 flake8-docstrings = "^1.6.0"
-mypy = "^0.812"
 pytest-mock = "^3.6.0"
     
 [build-system]


### PR DESCRIPTION
Dropping mypy as flake8-annotations does most of the good parts which are covered by mypy